### PR TITLE
Add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     reviewers:
       - "semestry/developers-nl"
     open-pull-requests-limit: 15
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    reviewers:
+      - "semestry/developers-nl"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
Ref. semestry/tasks#217

## Proposed changes

In addition to changes in the `npm` package-ecosystem dependabot now also looks at `github-actions`

## Security concerns

It is still important to test the application manually every now and then - this is usually not done for dependabot upgrades

## Testing

Dependabot only runs in the default branch, i.e. after this PR has been merged into it

## Documentation

N/A