### PR TITLE
Move reviewers to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Assign the development team to the entire repository
+* @semestry/mytimetable-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "semestry/mytimetable-developers"
     open-pull-requests-limit: 15
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "semestry/mytimetable-developers"
     open-pull-requests-limit: 15


### PR DESCRIPTION
Ref. semestry/tasks#225

## Proposed changes

Use CODEOWNERS file as the reviewers configuration has been removed

## Security concerns

N/A

## Testing

An existing [PR](https://github.com/semestry/room-display/pull/264) will be recreated with `@dependabot recreate` 

## Documentation

[GitHub Blog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)
