### PR TITLE
Harden supply chain with install-script lockdown and 7-day release cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 15
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -15,6 +18,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 15
+    cooldown:
+      default-days: 7
     versioning-strategy: "increase"
     groups:
       actions:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
Ref. semestry/tasks#235

## Proposed changes

Disable npm lifecycle scripts on install and require packages to be at least 7 days old  before installation, applied both to npm directly (.npmrc) and to Dependabot PR creation (.github/dependabot.yml).

## Security concerns

Improves security.

## Testing

Tested locally.

### Security related testing

- [ ] Input validation is in place, including server-side validation
- [ ] Input data is validated
- [ ] Output data is properly encoded
- [ ] No SQL Injection is possible
- [ ] Encryption keys, password and other credentials are not held in code
- [ ] Code passes all applicable items from the _Secure coding checklist_ in [RI-ISM-POL-24 Development of Secure Systems](https://tribalgroup.sharepoint.com/:b:/r/sites/GovernanceServices/Central%20Product%20Documents/Product%20Development/TRI-ISM-POL-24%20v8.6%2027001%202022%20Development%20of%20Secure%20Systems.pdf)

## Documentation

N/A